### PR TITLE
style: Format panic messages

### DIFF
--- a/shellfn-core/src/execute/item.rs
+++ b/shellfn-core/src/execute/item.rs
@@ -83,7 +83,7 @@ where
         .expect(PANIC_MSG);
 
     if !result.status.success() {
-        panic!(PANIC_MSG);
+        panic!("{}", PANIC_MSG);
     }
 
     String::from_utf8(result.stdout)

--- a/shellfn-core/src/execute/iter.rs
+++ b/shellfn-core/src/execute/iter.rs
@@ -90,7 +90,7 @@ where
         .map(|lres| lres.expect(PANIC_MSG).parse().expect(PANIC_MSG))
         .chain([()].into_iter().flat_map(move |_| {
             if !process.wait().unwrap().success() {
-                panic!(PANIC_MSG)
+                panic!("{}", PANIC_MSG)
             }
             std::iter::empty()
         }))
@@ -143,7 +143,7 @@ where
         )
         .chain([()].into_iter().flat_map(move |_| {
             if !process.wait().unwrap().success() {
-                panic!(PANIC_MSG)
+                panic!("{}", PANIC_MSG)
             }
             std::iter::empty()
         }))

--- a/shellfn-core/src/execute/void.rs
+++ b/shellfn-core/src/execute/void.rs
@@ -63,7 +63,7 @@ pub fn execute_void_panic<TArg, TEnvKey, TEnvVal>(
         .expect(PANIC_MSG);
 
     if !output.status.success() {
-        panic!(PANIC_MSG)
+        panic!("{}", PANIC_MSG)
     }
 }
 

--- a/shellfn-core/src/utils.rs
+++ b/shellfn-core/src/utils.rs
@@ -37,6 +37,6 @@ pub fn check_exit_code_panic(process: Child) {
     let output = process.wait_with_output().expect(PANIC_MSG);
 
     if !output.status.success() {
-            panic!(PANIC_MSG)
+            panic!("{}", PANIC_MSG)
     }
 }


### PR DESCRIPTION
Fixes warnings like:
```
warning: panic message is not a string literal
  --> shellfn-core/src/execute/item.rs:86:16
   |
86 |         panic!(PANIC_MSG);
   |                ^^^^^^^^^
   |
   = note: this usage of `panic!()` is deprecated; it will be a hard error in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
   = note: `#[warn(non_fmt_panics)]` on by default
help: add a "{}" format string to `Display` the message
   |
86 |         panic!("{}", PANIC_MSG);
   |                +++++
```