### PR TITLE
style: Explicitly make trait objects

### DIFF
--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -2,11 +2,11 @@ use shellfn::shell;
 use std::error::Error;
 
 #[shell(cmd = "python -m $MODULE")]
-fn run(module: &str) -> Result<String, Box<Error>> {
+fn run(module: &str) -> Result<String, Box<dyn Error>> {
     ""
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     run("calendar")
         .map(|output| println!("{}", output))
 }

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -2,12 +2,12 @@ use shellfn::shell;
 use std::error::Error;
 
 #[shell]
-fn list_modified(dir: &str) -> Result<impl Iterator<Item = String>, Box<Error>> { r#"
+fn list_modified(dir: &str) -> Result<impl Iterator<Item = String>, Box<dyn Error>> { r#"
     cd $DIR
     git status | grep '^\s*modified:' | awk '{print $2}'
 "# }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     for modified in list_modified(".")? {
         println!("You have modified the file: {}", modified);
     }

--- a/examples/python.rs
+++ b/examples/python.rs
@@ -2,7 +2,7 @@ use shellfn::shell;
 use std::error::Error;
 
 #[shell(cmd = "python -c")]
-fn pretty_json(json: &str, indent: u8, sort_keys: bool) -> Result<String, Box<Error>> { r#"
+fn pretty_json(json: &str, indent: u8, sort_keys: bool) -> Result<String, Box<dyn Error>> { r#"
 import os, json
 
 input = os.environ['JSON']
@@ -13,7 +13,7 @@ obj = json.loads(input)
 print(json.dumps(obj, indent=indent, sort_keys=sort_keys))
 "# }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let json = r#"{"foo": 42, "bar": { "baz": 10, "qux": [1, 2, 3]}}"#;
     let pretty_json = pretty_json(json, 2, false)?;
     println!("{}", pretty_json);

--- a/shellfn-core/src/error.rs
+++ b/shellfn-core/src/error.rs
@@ -29,7 +29,7 @@ impl<PE: StdError> StdError for Error<PE> {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match self {
             Error::NonUtf8Stdout(ref e)     => Some(e),
             Error::ParsingError(ref e)      => Some(e),
@@ -52,7 +52,7 @@ impl StdError for NeverError {
         ""
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         None
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,7 +4,7 @@ use shellfn::shell;
 use std::error::Error as StdError;
 use std::fmt::Display;
 
-type BoxedError = Box<StdError>;
+type BoxedError = Box<dyn StdError>;
 
 #[test]
 fn runs_simple_bash_script() {


### PR DESCRIPTION
Fixes warnings like:
```
warning: trait objects without an explicit `dyn` are deprecated
  --> shellfn-core/src/error.rs:32:32
   |
32 |     fn cause(&self) -> Option<&StdError> {
   |                                ^^^^^^^^
   |
   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
   = note: `#[warn(bare_trait_objects)]` on by default
help: if this is a dyn-compatible trait, use `dyn`
   |
32 |     fn cause(&self) -> Option<&dyn StdError> {
   |                                +++
```