### PR TITLE
style: Prevent ambiguity of ``into_iter`

### DIFF
--- a/shellfn-core/src/execute/iter.rs
+++ b/shellfn-core/src/execute/iter.rs
@@ -88,7 +88,7 @@ where
     BufReader::new(stdout)
         .lines()
         .map(|lres| lres.expect(PANIC_MSG).parse().expect(PANIC_MSG))
-        .chain([()].into_iter().flat_map(move |_| {
+        .chain([()].iter().flat_map(move |_| {
             if !process.wait().unwrap().success() {
                 panic!(PANIC_MSG)
             }
@@ -141,7 +141,7 @@ where
                         .map_err(Into::into)
                 )
         )
-        .chain([()].into_iter().flat_map(move |_| {
+        .chain([()].iter().flat_map(move |_| {
             if !process.wait().unwrap().success() {
                 panic!(PANIC_MSG)
             }


### PR DESCRIPTION
Prevent warning like this:
```
warning: this method call resolves to `<&[T; N] as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<[T; N] as IntoIterator>::into_iter` in Rust 2021
  --> shellfn-core/src/execute/iter.rs:91:21
   |
91 |         .chain([()].into_iter().flat_map(move |_| {
   |                     ^^^^^^^^^
   |
   = warning: this changes meaning in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/IntoIterator-for-arrays.html>
   = note: `#[warn(array_into_iter)]` on by default
help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
   |
91 |         .chain([()].iter().flat_map(move |_| {
   |                     ~~~~
help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
   |
91 |         .chain(IntoIterator::into_iter([()]).flat_map(move |_| {
   |                ++++++++++++++++++++++++    ~
```