### PR TITLE
style: Use `thiserror` for error implementation

### DIFF
--- a/shellfn-core/Cargo.toml
+++ b/shellfn-core/Cargo.toml
@@ -11,3 +11,4 @@ doctest = false
 
 [dependencies]
 itertools = "0.8.0"
+thiserror = "2"

--- a/shellfn-core/src/error.rs
+++ b/shellfn-core/src/error.rs
@@ -3,62 +3,22 @@ use std::io;
 use std::process::Output;
 use std::string::FromUtf8Error;
 
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error<PE: StdError> {
-    NonUtf8Stdout(FromUtf8Error),
-    ParsingError(PE),
-    ProcessNotSpawned(io::Error),
-    StdoutUnreadable(io::Error),
-    WaitFailed(io::Error),
+    #[error("subprocess stdout contains non-utf8 characters")]
+    NonUtf8Stdout(#[source] FromUtf8Error),
+    #[error("could not parse subprocess output")]
+    ParsingError(#[source] PE),
+    #[error("could not spawn subprocess")]
+    ProcessNotSpawned(#[source] io::Error),
+    #[error("could not read subprocess stdout")]
+    StdoutUnreadable(#[source] io::Error),
+    #[error("subprocess failed")]
+    WaitFailed(#[source] io::Error),
+    #[error("subprocess finished with error")]
     ProcessFailed(Output),
 }
 
 // TODO: replace with `!` after stabilization
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(thiserror::Error, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum NeverError {}
-
-impl<PE: StdError> StdError for Error<PE> {
-    fn description(&self) -> &str {
-        match self {
-            Error::NonUtf8Stdout(_)     => "subprocess stdout contains non-utf8 characters",
-            Error::ParsingError(_)      => "could not parse subprocess output",
-            Error::ProcessNotSpawned(_) => "could not spawn subprocess",
-            Error::StdoutUnreadable(_)  => "could not read subprocess stdout",
-            Error::WaitFailed(_)        => "subprocess failed",
-            Error::ProcessFailed(_)     => "subprocess finished with error",
-        }
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        match self {
-            Error::NonUtf8Stdout(ref e)     => Some(e),
-            Error::ParsingError(ref e)      => Some(e),
-            Error::ProcessNotSpawned(ref e) => Some(e),
-            Error::StdoutUnreadable(ref e)  => Some(e),
-            Error::WaitFailed(ref e)        => Some(e),
-            Error::ProcessFailed(_)         => None,
-        }
-    }
-}
-
-impl<PE: StdError> std::fmt::Display for Error<PE> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl StdError for NeverError {
-    fn description(&self) -> &str {
-        ""
-    }
-
-    fn cause(&self) -> Option<&StdError> {
-        None
-    }
-}
-
-impl std::fmt::Display for NeverError {
-    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        Ok(())
-    }
-}


### PR DESCRIPTION
The usage of `trait Error` has changed a lot in 6 years. Instead of trying to fix the manual implementation, use the `thiserror` crate to simplify the error type.

Prevents this warning:
```
warning: use of deprecated method `std::error::Error::description`: use the Display impl or to_string()
  --> shellfn-core/src/error.rs:46:30
   |
46 |         write!(f, "{}", self.description())
   |                              ^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```