### PR TITLE
build(deps): Update `itertools` to 0.14

### DIFF
--- a/shellfn-core/Cargo.toml
+++ b/shellfn-core/Cargo.toml
@@ -10,4 +10,4 @@ edition     = "2018"
 doctest = false
 
 [dependencies]
-itertools = "0.8.0"
+itertools = ">= 0.8, <=0.14"


### PR DESCRIPTION
Use a range to allow multiple versions of itertools, as the API has not been changed.