### PR TITLE
ci: Add GitHub CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: rust
-rust:
-  - stable
-  - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,6 @@ members = [
     "shellfn-core"
 ]
 
-[badges]
-travis-ci = { repository = "synek317/shellfn", branch = "master" }
-
 [lib]
 doctest = false
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ It allows you to wrap a script in any language with strongly typed functions. Th
 
 [![Crates.io](https://img.shields.io/crates/v/shellfn.svg)](https://crates.io/crates/shellfn)
 [![license](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kbknapp/clap-rs/blob/master/LICENSE-MIT)
-[![Build Status](https://travis-ci.org/synek317/shellfn.svg?branch=master)](https://travis-ci.org/synek317/shellfn)
 
 [Documentation](https://docs.rs/shellfn/)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //!
 //! [![Crates.io](https://img.shields.io/crates/v/shellfn.svg)](https://crates.io/crates/shellfn)
 //! [![license](http://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/kbknapp/clap-rs/blob/master/LICENSE-MIT)
-//! [![Build Status](https://travis-ci.org/synek317/shellfn.svg?branch=master)](https://travis-ci.org/synek317/shellfn)
 //!
 //! [Documentation](https://docs.rs/shellfn/)
 //!


### PR DESCRIPTION
Travis CI seems non-functional for this repo. Add a simple GitHub CI job to run the tests using the stable compiler.