### PR TITLE
Prevent clippy warnings

### DIFF
--- a/shellfn-attribute/src/block_builder.rs
+++ b/shellfn-attribute/src/block_builder.rs
@@ -141,10 +141,8 @@ impl BlockBuilder {
                         if let PathArguments::AngleBracketed(ref path_args) = segment.arguments {
                             if let Some(arg) = path_args.args.first() {
                                 if let GenericArgument::Binding(ref binding) = arg.value() {
-                                    if binding.ident == "Item" {
-                                        if is_result_type(&binding.ty) {
-                                            self.inner_result = true;
-                                        }
+                                    if binding.ident == "Item" && is_result_type(&binding.ty) {
+                                        self.inner_result = true;
                                     }
                                 }
                             }

--- a/shellfn-attribute/src/block_builder.rs
+++ b/shellfn-attribute/src/block_builder.rs
@@ -168,7 +168,7 @@ impl BlockBuilder {
         let env_names = envs.iter().map(|s| s.to_uppercase()).collect::<Vec<_>>();
         let env_vals = envs
             .iter()
-            .map(|e| Ident::new(&e, Span::call_site()))
+            .map(|e| Ident::new(e, Span::call_site()))
             .collect::<Vec<_>>();
 
         // replace envs in args, e.g. for

--- a/shellfn-attribute/src/block_builder.rs
+++ b/shellfn-attribute/src/block_builder.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::quote;
 use syn::{FnArg, GenericArgument, PathArguments, ReturnType, Type, TypeImplTrait, TypeParamBound};
 
-const PROGRAM: &'static str = "PROGRAM";
+const PROGRAM: &str = "PROGRAM";
 
 #[derive(Default)]
 pub struct BlockBuilder {

--- a/shellfn-attribute/src/block_builder.rs
+++ b/shellfn-attribute/src/block_builder.rs
@@ -154,7 +154,7 @@ impl BlockBuilder {
     }
 
     pub fn build(mut self) -> TokenStream2 {
-        if self.program.len() > 0 {
+        if !self.program.is_empty() {
             self.add_program_to_args();
         } else {
             self.args.retain(|a| a != PROGRAM);

--- a/shellfn-attribute/src/block_builder.rs
+++ b/shellfn-attribute/src/block_builder.rs
@@ -135,13 +135,13 @@ impl BlockBuilder {
                 if let Some(pair) = bound.path.segments.first() {
                     let segment = pair.value();
 
-                    if segment.ident.to_string() == "Iterator" {
+                    if segment.ident == "Iterator" {
                         self.output_type = OutputType::Iter;
 
                         if let PathArguments::AngleBracketed(ref path_args) = segment.arguments {
                             if let Some(arg) = path_args.args.first() {
                                 if let GenericArgument::Binding(ref binding) = arg.value() {
-                                    if binding.ident.to_string() == "Item" {
+                                    if binding.ident == "Item" {
                                         if is_result_type(&binding.ty) {
                                             self.inner_result = true;
                                         }

--- a/shellfn-attribute/src/lib.rs
+++ b/shellfn-attribute/src/lib.rs
@@ -22,7 +22,7 @@ pub fn shell(attr: TokenStream, input: TokenStream) -> TokenStream {
     if let Some(Stmt::Expr(Expr::Lit(ExprLit {
         lit: Lit::Str(ref program),
         ..
-    }))) = input.block.stmts.iter().next()
+    }))) = input.block.stmts.first()
     {
         let mut result = input.clone();
         let program = program.value();

--- a/shellfn-attribute/src/output_type.rs
+++ b/shellfn-attribute/src/output_type.rs
@@ -1,12 +1,8 @@
+#[derive(Default)]
 pub enum OutputType {
+    #[default]
     T,
     Iter,
     Vec,
     Void,
-}
-
-impl Default for OutputType {
-    fn default() -> Self {
-        OutputType::T
-    }
 }

--- a/shellfn-attribute/src/utils.rs
+++ b/shellfn-attribute/src/utils.rs
@@ -37,5 +37,5 @@ fn is_path_to(name: &str, type_path: &TypePath) -> bool {
         .path
         .segments
         .last()
-        .map_or(false, |s| s.value().ident.to_string() == name)
+        .is_some_and(|s| s.value().ident.to_string() == name)
 }

--- a/shellfn-attribute/src/utils.rs
+++ b/shellfn-attribute/src/utils.rs
@@ -37,5 +37,5 @@ fn is_path_to(name: &str, type_path: &TypePath) -> bool {
         .path
         .segments
         .last()
-        .is_some_and(|s| s.value().ident.to_string() == name)
+        .is_some_and(|s| s.value().ident == name)
 }

--- a/shellfn-core/src/execute/item.rs
+++ b/shellfn-core/src/execute/item.rs
@@ -39,7 +39,7 @@ where
     let result = process.wait_with_output().map_err(Error::WaitFailed)?;
 
     if !result.status.success() {
-        return Err(Error::ProcessFailed(result))?;
+        return Err(Error::ProcessFailed(result).into());
     }
 
     String::from_utf8(result.stdout)

--- a/shellfn-core/src/execute/iter.rs
+++ b/shellfn-core/src/execute/iter.rs
@@ -197,7 +197,7 @@ where
         )
         .map_or_else(
             || Either::Right(std::iter::empty()),
-            |iter| Either::Left(iter),
+            Either::Left,
         )
 }
 
@@ -240,7 +240,7 @@ where
         })
         .map_or_else(
             || Either::Right(std::iter::empty()),
-            |iter| Either::Left(iter),
+             Either::Left,
         )
 }
 

--- a/shellfn-core/src/execute/void.rs
+++ b/shellfn-core/src/execute/void.rs
@@ -99,12 +99,13 @@ where
     let status = process.wait().map_err(Error::WaitFailed)?;
 
     if !status.success() {
-        return Err(Error::ProcessFailed(Output {
+        Err(Error::ProcessFailed(Output {
             status,
             stdout: Vec::new(),
             stderr: Vec::new(),
-        }))?;
+        })
+        .into())
+    } else {
+        Ok(())
     }
-
-    Ok(())
 }

--- a/shellfn-core/src/utils.rs
+++ b/shellfn-core/src/utils.rs
@@ -27,10 +27,10 @@ pub fn check_exit_code<E: StdError>(process: Child) -> Result<(), Error<E>> {
     let output = process.wait_with_output().map_err(Error::WaitFailed)?;
 
     if !output.status.success() {
-        return Err(Error::ProcessFailed(output));
+        Err(Error::ProcessFailed(output))
+    } else {
+        Ok(())
     }
-
-    return Ok(());
 }
 
 pub fn check_exit_code_panic(process: Child) {

--- a/shellfn-core/src/utils.rs
+++ b/shellfn-core/src/utils.rs
@@ -4,7 +4,7 @@ use std::ffi::OsStr;
 use std::io;
 use std::process::{Child, Command, Stdio};
 
-pub const PANIC_MSG: &'static str = "Shell execution failed";
+pub const PANIC_MSG: &str = "Shell execution failed";
 
 pub fn spawn<TArg, TEnvKey, TEnvVal>(
     cmd: impl AsRef<OsStr>,


### PR DESCRIPTION
This PR fixes all `cargo clippy` warnings. I split each warning into a separate commit for ease of reviewing.