### PR TITLE
ci: Add clippy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  clippy_rust_version: '1.84'
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,3 +18,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.clippy_rust_version }}
+          components: clippy
+      - run: cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
Run `cargo clippy` in CI. Select a specific clippy version to prevent breakage due to new lints.