### PR TITLE
ci: Add Rust formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,15 @@ jobs:
           components: clippy
       - run: cargo clippy --workspace --all-targets -- -D warnings
 
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo +nightly fmt --all --check
+
   toml_validation:
     runs-on: ubuntu-latest
     container:

--- a/examples/calendar.rs
+++ b/examples/calendar.rs
@@ -7,6 +7,5 @@ fn run(module: &str) -> Result<String, Box<dyn Error>> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    run("calendar")
-        .map(|output| println!("{}", output))
+    run("calendar").map(|output| println!("{}", output))
 }

--- a/examples/git.rs
+++ b/examples/git.rs
@@ -2,10 +2,12 @@ use shellfn::shell;
 use std::error::Error;
 
 #[shell]
-fn list_modified(dir: &str) -> Result<impl Iterator<Item = String>, Box<dyn Error>> { r#"
+fn list_modified(dir: &str) -> Result<impl Iterator<Item = String>, Box<dyn Error>> {
+    r#"
     cd $DIR
     git status | grep '^\s*modified:' | awk '{print $2}'
-"# }
+    "#
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     for modified in list_modified(".")? {

--- a/examples/python.rs
+++ b/examples/python.rs
@@ -2,7 +2,8 @@ use shellfn::shell;
 use std::error::Error;
 
 #[shell(cmd = "python -c")]
-fn pretty_json(json: &str, indent: u8, sort_keys: bool) -> Result<String, Box<dyn Error>> { r#"
+fn pretty_json(json: &str, indent: u8, sort_keys: bool) -> Result<String, Box<dyn Error>> {
+    r#"
 import os, json
 
 input = os.environ['JSON']
@@ -11,7 +12,8 @@ sort_keys = os.environ['SORT_KEYS'] == 'true'
 obj = json.loads(input)
 
 print(json.dumps(obj, indent=indent, sort_keys=sort_keys))
-"# }
+    "#
+}
 
 fn main() -> Result<(), Box<dyn Error>> {
     let json = r#"{"foo": 42, "bar": { "baz": 10, "qux": [1, 2, 3]}}"#;

--- a/shellfn-attribute/src/attributes.rs
+++ b/shellfn-attribute/src/attributes.rs
@@ -3,7 +3,7 @@ use darling::FromMeta;
 #[derive(Debug, Default, FromMeta)]
 pub struct Attributes {
     #[darling(default = "default_cmd")]
-    pub cmd: String,
+    pub cmd:      String,
     #[darling(default)]
     pub no_panic: bool,
 }

--- a/shellfn-attribute/src/block_builder.rs
+++ b/shellfn-attribute/src/block_builder.rs
@@ -181,7 +181,7 @@ impl BlockBuilder {
         let args = self
             .args
             .into_iter()
-            .map(|arg|
+            .map(|arg| {
                 env_names
                     .iter()
                     .enumerate()
@@ -198,7 +198,7 @@ impl BlockBuilder {
                             arg_tokens
                         }
                     })
-            )
+            })
             .map(|tokens| quote! { #tokens.to_string() })
             .collect::<Vec<_>>();
 
@@ -223,6 +223,7 @@ impl BlockBuilder {
         }
     }
 
+    #[rustfmt::skip]
     fn select_execute_fn(&self) -> TokenStream2 {
         use OutputType::*;
 

--- a/shellfn-attribute/src/lib.rs
+++ b/shellfn-attribute/src/lib.rs
@@ -51,6 +51,8 @@ pub fn shell(attr: TokenStream, input: TokenStream) -> TokenStream {
         })
         .into()
     } else {
-        panic!(r"Invalid input. Expected fn containing only string literal without any other statements")
+        panic!(
+            r"Invalid input. Expected fn containing only string literal without any other statements"
+        )
     }
 }

--- a/shellfn-core/src/execute/iter.rs
+++ b/shellfn-core/src/execute/iter.rs
@@ -41,15 +41,15 @@ where
     let mut process = spawn(cmd, args, envs).map_err(Error::ProcessNotSpawned)?;
     let stdout = process.stdout.take().unwrap();
 
-    Ok(BufReader::new(stdout).lines().map(|lres|
+    Ok(BufReader::new(stdout).lines().map(|lres| {
         lres.map_err(Error::StdoutUnreadable)
             .map_err(Into::into)
-            .and_then(|line|
+            .and_then(|line| {
                 line.parse()
                     .map_err(Error::ParsingError)
                     .map_err(Into::into)
-            )
-    ))
+            })
+    }))
 }
 
 /// Executes command with args and environment variables, parses output line by line
@@ -132,15 +132,15 @@ where
 
     BufReader::new(stdout)
         .lines()
-        .map(|lres|
+        .map(|lres| {
             lres.map_err(Error::StdoutUnreadable)
                 .map_err(Into::into)
-                .and_then(|line|
+                .and_then(|line| {
                     line.parse()
                         .map_err(Error::ParsingError)
                         .map_err(Into::into)
-                )
-        )
+                })
+        })
         .chain([()].iter().flat_map(move |_| {
             if !process.wait().unwrap().success() {
                 panic!("{}", PANIC_MSG)
@@ -182,23 +182,20 @@ where
 {
     spawn(cmd, args, envs)
         .ok()
-        .map(|mut process|
+        .map(|mut process| {
             BufReader::new(process.stdout.take().unwrap())
                 .lines()
-                .map(|lres|
+                .map(|lres| {
                     lres.map_err(Error::StdoutUnreadable)
                         .map_err(Into::into)
-                        .and_then(|line|
+                        .and_then(|line| {
                             line.parse()
                                 .map_err(Error::ParsingError)
                                 .map_err(Into::into)
-                        )
-                )
-        )
-        .map_or_else(
-            || Either::Right(std::iter::empty()),
-            Either::Left,
-        )
+                        })
+                })
+        })
+        .map_or_else(|| Either::Right(std::iter::empty()), Either::Left)
 }
 
 /// Executes command with args and environment variables, parses output line by line
@@ -238,10 +235,7 @@ where
                 .lines()
                 .filter_map(|lres| lres.ok().and_then(|line| line.parse().ok()))
         })
-        .map_or_else(
-            || Either::Right(std::iter::empty()),
-             Either::Left,
-        )
+        .map_or_else(|| Either::Right(std::iter::empty()), Either::Left)
 }
 
 /// Executes command with args and environment variables, parses output line by line

--- a/shellfn-core/src/execute/vec.rs
+++ b/shellfn-core/src/execute/vec.rs
@@ -42,15 +42,15 @@ where
     let stdout = process.stdout.take().unwrap();
     let result = BufReader::new(stdout)
         .lines()
-        .map(|lres| lres
-            .map_err(Error::StdoutUnreadable)
-            .map_err(Into::into)
-            .and_then(|line|
-                line.parse()
-                    .map_err(Error::ParsingError)
-                    .map_err(Into::into)
-            )
-        )
+        .map(|lres| {
+            lres.map_err(Error::StdoutUnreadable)
+                .map_err(Into::into)
+                .and_then(|line| {
+                    line.parse()
+                        .map_err(Error::ParsingError)
+                        .map_err(Into::into)
+                })
+        })
         .collect::<Vec<_>>();
 
     check_exit_code(process)?;
@@ -91,11 +91,7 @@ where
     let stdout = process.stdout.take().unwrap();
     let result = BufReader::new(stdout)
         .lines()
-        .map(|lres| lres
-            .expect(PANIC_MSG)
-            .parse()
-            .expect(PANIC_MSG)
-        )
+        .map(|lres| lres.expect(PANIC_MSG).parse().expect(PANIC_MSG))
         .collect::<Vec<_>>();
 
     check_exit_code_panic(process);
@@ -137,15 +133,15 @@ where
     let stdout = process.stdout.take().unwrap();
     let result = BufReader::new(stdout)
         .lines()
-        .map(|lres| lres
-            .map_err(Error::StdoutUnreadable)
-            .map_err(Into::into)
-            .and_then(|line|
-                line.parse()
-                    .map_err(Error::ParsingError)
-                    .map_err(Into::into)
-            )
-        )
+        .map(|lres| {
+            lres.map_err(Error::StdoutUnreadable)
+                .map_err(Into::into)
+                .and_then(|line| {
+                    line.parse()
+                        .map_err(Error::ParsingError)
+                        .map_err(Into::into)
+                })
+        })
         .collect::<Vec<_>>();
 
     check_exit_code_panic(process);
@@ -171,7 +167,7 @@ where
 /// assert_eq!(vec![1, 2, 3], command().map(Result::unwrap).collect::<Vec<_>>())
 /// ```
 pub fn execute_vec_nopanic_result<T, TArg, TEnvKey, TEnvVal, TError>(
-    cmd:  impl AsRef<OsStr>,
+    cmd: impl AsRef<OsStr>,
     args: impl IntoIterator<Item = TArg>,
     envs: impl IntoIterator<Item = (TEnvKey, TEnvVal)>,
 ) -> Vec<Result<T, TError>>
@@ -184,20 +180,20 @@ where
     TError: From<Error<<T as FromStr>::Err>>,
 {
     spawn(cmd, args, envs)
-        .map(|mut process|
+        .map(|mut process| {
             BufReader::new(process.stdout.take().unwrap())
                 .lines()
-                .map(|lres|
+                .map(|lres| {
                     lres.map_err(Error::StdoutUnreadable)
                         .map_err(Into::into)
-                        .and_then(|line|
+                        .and_then(|line| {
                             line.parse()
                                 .map_err(Error::ParsingError)
                                 .map_err(Into::into)
-                        )
-                )
+                        })
+                })
                 .collect::<Vec<_>>()
-        )
+        })
         .unwrap_or(Vec::default())
 }
 

--- a/shellfn-core/src/utils.rs
+++ b/shellfn-core/src/utils.rs
@@ -37,6 +37,6 @@ pub fn check_exit_code_panic(process: Child) {
     let output = process.wait_with_output().expect(PANIC_MSG);
 
     if !output.status.success() {
-            panic!("{}", PANIC_MSG)
+        panic!("{}", PANIC_MSG)
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -9,9 +9,11 @@ type BoxedError = Box<dyn StdError>;
 #[test]
 fn runs_simple_bash_script() {
     #[shell]
-    fn subject() -> String { r#"
+    fn subject() -> String {
+        r#"
         echo -n "Hello, bash!"
-    "# }
+        "#
+    }
 
     assert_eq!("Hello, bash!", subject())
 }
@@ -19,11 +21,13 @@ fn runs_simple_bash_script() {
 #[test]
 fn runs_simple_python_script() {
     #[shell(cmd = "python -c")]
-    fn subject() -> String { r#"
+    fn subject() -> String {
+        r#"
 import sys
 hello = lambda: "Hello, python!"
 sys.stdout.write(hello())
-    "# }
+        "#
+    }
 
     assert_eq!("Hello, python!", subject())
 }
@@ -31,14 +35,16 @@ sys.stdout.write(hello())
 #[test]
 fn runs_script_with_program_on_custom_position() {
     #[shell(cmd = "python -c PROGRAM --world python")]
-    fn subject() -> String { r#"
+    fn subject() -> String {
+        r#"
 import sys
 from argparse import ArgumentParser
 parser = ArgumentParser()
 parser.add_argument("-w", "--world", dest="world")
 args = parser.parse_args()
 sys.stdout.write("Hello, " + args.world + "!")
-    "# }
+        "#
+    }
 
     assert_eq!("Hello, python!", subject())
 }
@@ -46,9 +52,11 @@ sys.stdout.write("Hello, " + args.world + "!")
 #[test]
 fn sets_env_vars() {
     #[shell]
-    fn subject(world: impl Display, foo: u32) -> String { r#"
+    fn subject(world: impl Display, foo: u32) -> String {
+        r#"
         echo -n "Hello, $WORLD! The answer is $FOO"
-    "# }
+        "#
+    }
 
     assert_eq!("Hello, world! The answer is 42", subject("world", 42));
 }
@@ -56,7 +64,9 @@ fn sets_env_vars() {
 #[test]
 fn replaces_env_vars_in_args() {
     #[shell(cmd = "bash -c \"echo -n Hello, $WORLD! The answer is $FOO\"")]
-    fn subject(world: impl Display, foo: u32) -> String { "" }
+    fn subject(world: impl Display, foo: u32) -> String {
+        ""
+    }
 
     assert_eq!("Hello, world! The answer is 42", subject("world", 42));
 }
@@ -64,9 +74,11 @@ fn replaces_env_vars_in_args() {
 #[test]
 fn parses_return_value() {
     #[shell]
-    fn join(x: u32, y: u32) -> u32 { r#"
+    fn join(x: u32, y: u32) -> u32 {
+        r#"
         echo -n $X$Y
-    "# }
+        "#
+    }
 
     assert_eq!(4224, join(42, 24));
 }
@@ -83,9 +95,11 @@ mod analyzes_return_type {
             #[test]
             fn does_nothing_when_script_ends_with_success() {
                 #[shell]
-                fn script() { r#"
+                fn script() {
+                    r#"
                     echo -n ""
-                "# }
+                    "#
+                }
 
                 script()
             }
@@ -94,9 +108,11 @@ mod analyzes_return_type {
             #[should_panic]
             fn panics_when_script_ends_with_failure() {
                 #[shell]
-                fn script() { r#"
+                fn script() {
+                    r#"
                     exit 1
-                "# }
+                    "#
+                }
 
                 script()
             }
@@ -105,9 +121,11 @@ mod analyzes_return_type {
             #[should_panic]
             fn panics_when_script_is_invalid() {
                 #[shell]
-                fn script() { r#"
+                fn script() {
+                    r#"
                     invalid script
-                "# }
+                    "#
+                }
 
                 script()
             }
@@ -119,9 +137,11 @@ mod analyzes_return_type {
             #[test]
             fn does_nothing_when_script_ends_with_success() {
                 #[shell(no_panic)]
-                fn script() { r#"
+                fn script() {
+                    r#"
                     echo -n ""
-                "# }
+                    "#
+                }
 
                 script()
             }
@@ -129,9 +149,11 @@ mod analyzes_return_type {
             #[test]
             fn does_nothing_when_script_ends_with_failure() {
                 #[shell(no_panic)]
-                fn script() { r#"
+                fn script() {
+                    r#"
                     exit 1
-                "# }
+                    "#
+                }
 
                 script()
             }
@@ -139,9 +161,11 @@ mod analyzes_return_type {
             #[test]
             fn does_nothing_when_script_is_invalid() {
                 #[shell(no_panic)]
-                fn script() { r#"
+                fn script() {
+                    r#"
                     invalid script
-                "# }
+                    "#
+                }
 
                 script()
             }
@@ -155,14 +179,18 @@ mod analyzes_return_type {
             use super::*;
 
             #[shell]
-            fn script(interval: &str) -> () { r#"
+            fn script(interval: &str) -> () {
+                r#"
                 sleep $INTERVAL
-            "# }
+                "#
+            }
 
             #[shell(cmd = "dummy_invalid_command_123")]
-            fn invalid_script() -> () { r#"
+            fn invalid_script() -> () {
+                r#"
                 invalid script
-            "# }
+                "#
+            }
 
             #[test]
             fn does_nothing_when_script_ends_with_success() {
@@ -186,14 +214,18 @@ mod analyzes_return_type {
             use super::*;
 
             #[shell]
-            fn script(interval: &str) -> Result<(), BoxedError> { r#"
+            fn script(interval: &str) -> Result<(), BoxedError> {
+                r#"
                 sleep $INTERVAL
-            "# }
+                "#
+            }
 
             #[shell(cmd = "dummy_invalid_command_123")]
-            fn invalid_script() -> Result<(), BoxedError> { r#"
+            fn invalid_script() -> Result<(), BoxedError> {
+                r#"
                 invalid script
-            "# }
+                "#
+            }
 
             #[test]
             fn returns_ok_when_script_ends_with_success() {
@@ -219,15 +251,19 @@ mod analyzes_return_type {
             use super::*;
 
             #[shell]
-            fn script(data: &str, exit_code: u32) -> u32 { r#"
+            fn script(data: &str, exit_code: u32) -> u32 {
+                r#"
                 echo -n $DATA
                 exit $EXIT_CODE
-            "# }
+                "#
+            }
 
             #[shell(cmd = "dummy_invalid_command_123")]
-            fn invalid_script() -> u32 { r#"
+            fn invalid_script() -> u32 {
+                r#"
                 invalid script
-            "# }
+                "#
+            }
 
             #[test]
             fn returns_parsed_value_when_script_ends_with_success() {
@@ -257,15 +293,19 @@ mod analyzes_return_type {
             use super::*;
 
             #[shell]
-            fn script(data: &str, exit_code: u32) -> Result<u32, BoxedError> { r#"
+            fn script(data: &str, exit_code: u32) -> Result<u32, BoxedError> {
+                r#"
                 echo -n $DATA
                 exit $EXIT_CODE
-            "# }
+                "#
+            }
 
             #[shell(cmd = "dummy_invalid_command_123")]
-            fn invalid_script() -> Result<u32, BoxedError> { r#"
+            fn invalid_script() -> Result<u32, BoxedError> {
+                r#"
                 invalid script
-            "# }
+                "#
+            }
 
             #[test]
             fn returns_parsed_value_when_script_ends_with_success() {
@@ -302,18 +342,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell]
-                    fn script(data: &str, exit_code: u32) -> impl Iterator<Item=u32> { r#"
+                    fn script(data: &str, exit_code: u32) -> impl Iterator<Item = u32> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                       "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123")]
-                    fn invalid_script() -> impl Iterator<Item=u32> { r#"
+                    fn invalid_script() -> impl Iterator<Item = u32> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsed_values_when_script_ends_with_success() {
@@ -345,22 +389,29 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell(no_panic)]
-                    fn script(data: &str, exit_code: u32) -> impl Iterator<Item=u32> { r#"
+                    fn script(data: &str, exit_code: u32) -> impl Iterator<Item = u32> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123", no_panic)]
-                    fn invalid_script() -> impl Iterator<Item=u32> { r#"
+                    fn invalid_script() -> impl Iterator<Item = u32> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_only_successfuly_parsed_values_when_script_ends_with_success() {
-                        assert_eq!(vec![42, 100], script("42 FOO 100 BAR", 0).collect::<Vec<_>>())
+                        assert_eq!(
+                            vec![42, 100],
+                            script("42 FOO 100 BAR", 0).collect::<Vec<_>>()
+                        )
                     }
 
                     #[test]
@@ -382,18 +433,25 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell]
-                    fn script(data: &str, exit_code: u32) -> impl Iterator<Item=Result<u32, BoxedError>> { r#"
+                    fn script(
+                        data: &str,
+                        exit_code: u32,
+                    ) -> impl Iterator<Item = Result<u32, BoxedError>> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123")]
-                    fn invalid_script() -> impl Iterator<Item=Result<u32, BoxedError>> { r#"
+                    fn invalid_script() -> impl Iterator<Item = Result<u32, BoxedError>> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsing_results_when_script_ends_with_success() {
@@ -422,18 +480,25 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell(no_panic)]
-                    fn script(data: &str, exit_code: u32) -> impl Iterator<Item=Result<u32, BoxedError>> { r#"
+                    fn script(
+                        data: &str,
+                        exit_code: u32,
+                    ) -> impl Iterator<Item = Result<u32, BoxedError>> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123", no_panic)]
-                    fn invalid_script() -> impl Iterator<Item=Result<u32, BoxedError>> { r#"
+                    fn invalid_script() -> impl Iterator<Item = Result<u32, BoxedError>> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsing_results_when_script_ends_with_success() {
@@ -474,18 +539,25 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell]
-                    fn script(data: &str, exit_code: u32) -> Result<impl Iterator<Item=u32>, BoxedError> { r#"
+                    fn script(
+                        data: &str,
+                        exit_code: u32,
+                    ) -> Result<impl Iterator<Item = u32>, BoxedError> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123")]
-                    fn invalid_script() -> Result<impl Iterator<Item=u32>, BoxedError> { r#"
+                    fn invalid_script() -> Result<impl Iterator<Item = u32>, BoxedError> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsed_values_when_script_ends_with_success() {
@@ -505,7 +577,8 @@ mod analyzes_return_type {
                     #[test]
                     #[should_panic]
                     fn panics_when_parsing_fails() {
-                        let _ = script("100 DEFINITELY_NOT_INT", 0).map(|items| items.collect::<Vec<_>>());
+                        let _ = script("100 DEFINITELY_NOT_INT", 0)
+                            .map(|items| items.collect::<Vec<_>>());
                     }
 
                     #[test]
@@ -518,18 +591,25 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell(no_panic)]
-                    fn script(data: &str, exit_code: u32) -> Result<impl Iterator<Item=u32>, BoxedError> { r#"
+                    fn script(
+                        data: &str,
+                        exit_code: u32,
+                    ) -> Result<impl Iterator<Item = u32>, BoxedError> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123", no_panic)]
-                    fn invalid_script() -> Result<impl Iterator<Item=u32>, BoxedError> { r#"
+                    fn invalid_script() -> Result<impl Iterator<Item = u32>, BoxedError> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_only_successfuly_parsed_values_when_script_ends_with_success() {
@@ -556,18 +636,28 @@ mod analyzes_return_type {
                 use super::*;
 
                 #[shell]
-                fn script(data: &str, exit_code: u32) -> Result<impl Iterator<Item=Result<u32, BoxedError>>, BoxedError> { r#"
+                fn script(
+                    data: &str,
+                    exit_code: u32,
+                ) -> Result<impl Iterator<Item = Result<u32, BoxedError>>, BoxedError>
+                {
+                    r#"
                     for V in $DATA; do
                         echo $V;
                     done
 
                     exit $EXIT_CODE
-                "# }
+                    "#
+                }
 
                 #[shell(cmd = "dummy_invalid_command_123")]
-                fn invalid_script() -> Result<impl Iterator<Item=Result<u32, BoxedError>>, BoxedError> { r#"
+                fn invalid_script(
+                ) -> Result<impl Iterator<Item = Result<u32, BoxedError>>, BoxedError>
+                {
+                    r#"
                     invalid script iter
-                "# }
+                    "#
+                }
 
                 #[test]
                 fn returns_parsing_results_when_script_ends_with_success() {
@@ -612,18 +702,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell]
-                    fn script(data: &str, exit_code: u32) -> Vec<u32> { r#"
+                    fn script(data: &str, exit_code: u32) -> Vec<u32> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123")]
-                    fn invalid_script() -> Vec<u32> { r#"
+                    fn invalid_script() -> Vec<u32> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsed_values_when_script_ends_with_success() {
@@ -655,18 +749,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell(no_panic)]
-                    fn script(data: &str, exit_code: u32) -> Vec<u32> { r#"
+                    fn script(data: &str, exit_code: u32) -> Vec<u32> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123", no_panic)]
-                    fn invalid_script() -> Vec<u32> { r#"
+                    fn invalid_script() -> Vec<u32> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_only_successfuly_parsed_values_when_script_ends_with_success() {
@@ -692,18 +790,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell]
-                    fn script(data: &str, exit_code: u32) -> Vec<Result<u32, BoxedError>> { r#"
+                    fn script(data: &str, exit_code: u32) -> Vec<Result<u32, BoxedError>> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123")]
-                    fn invalid_script() -> Vec<Result<u32, BoxedError>> { r#"
+                    fn invalid_script() -> Vec<Result<u32, BoxedError>> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsing_results_when_script_ends_with_success() {
@@ -732,18 +834,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell(no_panic)]
-                    fn script(data: &str, exit_code: u32) -> Vec<Result<u32, BoxedError>> { r#"
+                    fn script(data: &str, exit_code: u32) -> Vec<Result<u32, BoxedError>> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123", no_panic)]
-                    fn invalid_script() -> Vec<Result<u32, BoxedError>> { r#"
+                    fn invalid_script() -> Vec<Result<u32, BoxedError>> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsing_results_when_script_ends_with_success() {
@@ -784,18 +890,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell]
-                    fn script(data: &str, exit_code: u32) -> Result<Vec<u32>, BoxedError> { r#"
+                    fn script(data: &str, exit_code: u32) -> Result<Vec<u32>, BoxedError> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123")]
-                    fn invalid_script() -> Result<Vec<u32>, BoxedError> { r#"
+                    fn invalid_script() -> Result<Vec<u32>, BoxedError> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_parsed_values_when_script_ends_with_success() {
@@ -825,18 +935,22 @@ mod analyzes_return_type {
                     use super::*;
 
                     #[shell(no_panic)]
-                    fn script(data: &str, exit_code: u32) -> Result<Vec<u32>, BoxedError> { r#"
+                    fn script(data: &str, exit_code: u32) -> Result<Vec<u32>, BoxedError> {
+                        r#"
                         for V in $DATA; do
                             echo $V;
                         done
 
                         exit $EXIT_CODE
-                    "# }
+                        "#
+                    }
 
                     #[shell(cmd = "dummy_invalid_command_123", no_panic)]
-                    fn invalid_script() -> Result<Vec<u32>, BoxedError> { r#"
+                    fn invalid_script() -> Result<Vec<u32>, BoxedError> {
+                        r#"
                         invalid script iter
-                    "# }
+                        "#
+                    }
 
                     #[test]
                     fn returns_only_successfuly_parsed_values_when_script_ends_with_success() {
@@ -861,18 +975,25 @@ mod analyzes_return_type {
                 use super::*;
 
                 #[shell]
-                fn script(data: &str, exit_code: u32) -> Result<Vec<Result<u32, BoxedError>>, BoxedError> { r#"
+                fn script(
+                    data: &str,
+                    exit_code: u32,
+                ) -> Result<Vec<Result<u32, BoxedError>>, BoxedError> {
+                    r#"
                     for V in $DATA; do
                         echo $V;
                     done
 
                     exit $EXIT_CODE
-                "# }
+                    "#
+                }
 
                 #[shell(cmd = "dummy_invalid_command_123")]
-                fn invalid_script() -> Result<Vec<Result<u32, BoxedError>>, BoxedError> { r#"
+                fn invalid_script() -> Result<Vec<Result<u32, BoxedError>>, BoxedError> {
+                    r#"
                     invalid script iter
-                "# }
+                    "#
+                }
 
                 #[test]
                 fn returns_parsing_results_when_script_ends_with_success() {


### PR DESCRIPTION
This project uses a nightly-only formatting option.

The formatter really wants the function body starting on a new line. So `shellfn` function bodies are differently formatted the before, but they are now formatted as it would for the crate users.